### PR TITLE
Make QR code truly centred

### DIFF
--- a/qr_blend.py
+++ b/qr_blend.py
@@ -45,7 +45,7 @@ bpy.ops.object.convert(target='MESH')
 bpy.ops.object.join()
 
 # reset object origin (useful for scaling and keeping things centered)
-bpy.ops.object.origin_set(type='GEOMETRY_ORIGIN', center='MEDIAN')
+bpy.ops.object.origin_set(type='GEOMETRY_ORIGIN', center='BOUNDS')
 
 # resize based on qr_length
 bpy.context.active_object.dimensions = (qr_length, qr_length, qr_length)


### PR DESCRIPTION
Currently the actual QR code might be slight off-centre because "median" seemingly calculates its centre from the distribution of elements in it. The imported SVG has correct bounds, so it's better to use those.